### PR TITLE
Add Dockerfile and docs to build and run it. Discussed in #2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+FROM mambaorg/micromamba:latest
+
+WORKDIR /model
+
+RUN micromamba install \
+        --name base \
+        --yes \
+        'python<3.11' \
+                gcc \
+                gxx \
+                pip \
+                wget \
+                unzip \
+                huggingface_hub \
+ && /opt/conda/bin/wget https://raw.githubusercontent.com/nasaharvest/galileo/refs/heads/main/requirements.txt \
+    -O /model/requirements.txt \
+ && micromamba run \
+    -n base \
+    pip install -r /model/requirements.txt zarr \
+ && micromamba run \
+    -n base \
+    pip cache purge \
+ && rm /model/requirements.txt \
+ && micromamba clean --all --yes
+
+# Clone latest version of the model code
+RUN /opt/conda/bin/wget https://github.com/nasaharvest/galileo/archive/refs/heads/main.zip -O /model/galileo.zip \
+ && /opt/conda/bin/unzip /model/galileo.zip \
+ && mv galileo-main galileo \
+ && rm galileo.zip
+
+# Pull tiny and base models
+RUN mkdir /model/galileo/data/models/tiny \
+ && cd /model/galileo/data/models/tiny \
+ && /opt/conda/bin/wget \
+    https://huggingface.co/nasaharvest/galileo/resolve/main/models/tiny/config.json \
+    https://huggingface.co/nasaharvest/galileo/resolve/main/models/tiny/decoder.pt \
+    https://huggingface.co/nasaharvest/galileo/resolve/main/models/tiny/encoder.pt \
+    https://huggingface.co/nasaharvest/galileo/resolve/main/models/tiny/second_decoder.pt \
+    https://huggingface.co/nasaharvest/galileo/resolve/main/models/tiny/target_encoder.pt \
+ && mkdir /model/galileo/data/models/base \
+ && cd /model/galileo/data/models/base \
+ && /opt/conda/bin/wget \
+    https://huggingface.co/nasaharvest/galileo/resolve/main/models/tiny/config.json \
+    https://huggingface.co/nasaharvest/galileo/resolve/main/models/tiny/decoder.pt \
+    https://huggingface.co/nasaharvest/galileo/resolve/main/models/tiny/encoder.pt \
+    https://huggingface.co/nasaharvest/galileo/resolve/main/models/tiny/second_decoder.pt \
+    https://huggingface.co/nasaharvest/galileo/resolve/main/models/tiny/target_encoder.pt \
+ && printf "from pathlib import Path\n\nNANO = Path('/model/galileo/data/models/nano')\nTINY = Path('/model/galileo/data/models/tiny')\nBASE = Path('/model/galileo/data/models/base')" > /model/galileo/model_paths.py
+
+ENV PYTHONPATH="${PYTHONPATH}:/model/galileo:/model"
+
+# Entry point
+CMD ["jupyter-lab", "--ip", "0.0.0.0", "--port", "8888", "--allow-root"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,4 +51,4 @@ RUN mkdir /model/galileo/data/models/tiny \
 ENV PYTHONPATH="${PYTHONPATH}:/model/galileo:/model"
 
 # Entry point
-CMD ["jupyter-lab", "--ip", "0.0.0.0", "--port", "8888", "--allow-root"]
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -97,8 +97,6 @@ docker run \
 	--rm \
 	-ti \
 	--gpus all \
-	-p 8882:8888 \
-	-v /home/dani:/model/work \
 	galileo
 ```
 
@@ -106,12 +104,16 @@ Notes:
 
 - The command above will use GPUs available on the host system, but requires
   the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) installed and propertly working. If you do not have or do not want to use the GPU, you can drop the argument.
-- As stated above, the image does not mount any folder in the host. If you
+- As stated above, the image runs fully isolated from the host. If you
   want to connect the running container to a folder, you can use the
   `--volume` argument and map a folder (see the official docs
   [here](https://docker-docs.uclv.cu/storage/volumes/)). In that case, you
   might have to run the container as root, which you can do by adding the
-  argument `--user root`.
+  argument `--user root`. Similarly, if you want to launch `jupyter lab`
+  (included), you'll have to map the 8888 port with `--port`.
+- This image is built for x86 chips (e.g., Intel, AMD). Apple Silicon users
+  will need to add the following flag to their `docker build` and `docker run`
+  commands: `--platform linux/amd64`
 
 ### Reference
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,47 @@ You can download them locally with the following command (you will need to insta
 hf download nasaharvest/galileo --include "models/**" --local-dir data
 ```
 
+#### Docker setup
+
+A `Dockerfile` is available to build a container that includes all
+dependencies as well as the models, served in a JupyterLab environment. To
+build the image:
+
+- Download the [Dockerfile](Dockerfile) locally.
+- Change directory on the command line to the folder where you have downloaded
+  the file:
+
+  `cd /path/to/folder/with_Dockerfile`
+
+- Assuming you have [Docker](https://docker.com) (or a compatible app like
+  `podman`), run:
+
+  ```bash
+  docker build -t galileo .
+  ```
+
+Once completed, you can run the built image with:
+
+```bash
+docker run \
+	--rm \
+	-ti \
+	--gpus all \
+	-p 8882:8888 \
+	-v /home/dani:/model/work \
+	galileo
+```
+
+Notes:
+
+- The command above will use GPUs available on the host system, but requires
+  the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) installed and propertly working. If you do not have or do not want to use the GPU, you can drop the argument.
+- As stated above, the image does not mount any folder in the host. If you
+  want to connect the running container to a folder, you can use the
+  `--volume` argument and map a folder (see the official docs
+  [here](https://docker-docs.uclv.cu/storage/volumes/)). In that case, you
+  might have to run the container as root, which you can do by adding the
+  argument `--user root`.
 
 ### Reference
 


### PR DESCRIPTION
This PR adds a `Dockerfile` that builds a Docker image with everything required to run the Galileo models, included the model weights and the official Galileo (grabbed from `main` on build time). A description of how to build and run the image is provided under the "Docker setup" section in the `README.md`.