### PR TITLE
1059 robin  s2 nodata defective filter

### DIFF
--- a/copernicus_marimo.py
+++ b/copernicus_marimo.py
@@ -320,6 +320,17 @@ def _(datetime, mo, timedelta):
         label="Crop to target area only (faster, less memory)",
     )
 
+    # Quality threshold slider — shared by S1 and S2
+    # Controls the minimum usable-pixel % to ACCEPT a tile
+    quality_threshold = mo.ui.slider(
+        start=50,
+        stop=100,
+        step=1,
+        value=90,
+        label="Quality threshold (% usable pixels to accept)",
+        show_value=True,
+    )
+
     # Search button triggers the search and download
     search_button = mo.ui.run_button(label="🔍 Search & Download")
 
@@ -331,6 +342,7 @@ def _(datetime, mo, timedelta):
         max_products,
         min_lat,
         min_lon,
+        quality_threshold,
         satellite_type,
         search_button,
         start_date,
@@ -347,6 +359,7 @@ def _(
     min_lat,
     min_lon,
     mo,
+    quality_threshold,
     satellite_type,
     search_button,
     start_date,
@@ -377,6 +390,13 @@ def _(
                 """
             ),
             crop_to_bbox,
+            mo.md(
+                """
+                **Quality Gate**: Minimum % of usable pixels to accept a tile.
+                Tiles below (threshold − 10%) are rejected; in between is marginal.
+                """
+            ),
+            quality_threshold,
             mo.callout(
                 mo.md(
                     """
@@ -707,6 +727,7 @@ def _(
     min_lat,
     min_lon,
     mo,
+    quality_threshold,
     satellite_type,
 ):
     """Create time slider and pre-process all images for fast rendering.
@@ -714,7 +735,8 @@ def _(
     This cell:
     1. Extracts dates from filenames and creates metadata
     2. Pre-processes ALL images into memory (cached)
-    3. Creates slider widget for navigation
+    3. Runs quality assessment (S1: invalid pixels / border noise, S2: cloud mask)
+    4. Creates slider widget for navigation
 
     Pre-processing happens once, making slider interactions instant.
     The crop_to_bbox option controls whether to show full context or just target area.
@@ -746,6 +768,9 @@ def _(
             # Get bbox for optional cropping
             _bbox = [min_lon.value, min_lat.value, max_lon.value, max_lat.value]
             _use_bbox = crop_to_bbox.value  # User's choice
+
+            # Import quality functions
+            from src.data.copernicus.quality import assess_s1_quality, quality_gate
 
             # Extract dates and pre-process images
             for _idx, _file_path in enumerate(_files_to_visualize):
@@ -787,6 +812,21 @@ def _(
                         _processed_data is not None
                         and _processed_data.get("bounds_wgs84") is not None
                     ):
+                        # --- Quality assessment ---
+                        _quality_report = None
+                        _quality_verdict = None
+
+                        if _viz_satellite_type == "S1":
+                            _spinner.update(
+                                title=f"Quality check {_idx + 1}/{len(_files_to_visualize)}..."
+                            )
+                            _quality_report = assess_s1_quality(_file_path)
+                            if _quality_report is not None:
+                                _quality_verdict = quality_gate(
+                                    _quality_report["usable_pct"],
+                                    threshold=quality_threshold.value,
+                                )
+
                         # Store metadata and cached image data
                         file_metadata.append(
                             {
@@ -794,6 +834,8 @@ def _(
                                 "date": _date_obj,
                                 "date_str": _date_display,
                                 "filename": _filename,
+                                "quality_report": _quality_report,
+                                "quality_verdict": _quality_verdict,
                             }
                         )
                         cached_images.append(_processed_data)
@@ -1059,6 +1101,7 @@ def _(
     min_lat,
     min_lon,
     mo,
+    quality_threshold,
     satellite_type,
     time_slider,
     traceback,
@@ -1352,10 +1395,30 @@ def _(
                 ax.set_xlabel("Longitude (°E)", fontsize=12)
                 ax.set_ylabel("Latitude (°N)", fontsize=12)
 
-                # Update title to show recipe name
+                # Update title to show recipe name and quality badge
                 _recipe_name = _selected_recipe if _selected_recipe else satellite_type.value
+
+                # Build quality badge string for S1 tiles
+                _quality_badge = ""
+                _qr = _metadata.get("quality_report")
+                if _qr is not None:
+                    from src.data.copernicus.quality import quality_gate as _qg
+
+                    _verdict = _qg(_qr["usable_pct"], threshold=quality_threshold.value)
+                    if _verdict == "ACCEPT":
+                        _quality_badge = f"  🟢 ACCEPT — {_qr['usable_pct']:.1f}% valid"
+                    elif _verdict == "MARGINAL":
+                        _quality_badge = f"  🟡 MARGINAL — {_qr['usable_pct']:.1f}% valid"
+                    else:
+                        _quality_badge = f"  🔴 REJECT — {_qr['usable_pct']:.1f}% valid"
+                    if _qr.get("border_noise_detected"):
+                        _quality_badge += "  ⚠️ border noise"
+                    if _qr.get("orbit_type"):
+                        _quality_badge += f"  | orbit: {_qr['orbit_type']}"
+
                 _title = (
-                    f"{_recipe_name} - {_metadata['date_str']}\n{_metadata['filename'][:50]}..."
+                    f"{_recipe_name} - {_metadata['date_str']}\n"
+                    f"{_metadata['filename'][:50]}...{_quality_badge}"
                 )
                 ax.set_title(_title, fontsize=11, fontweight="bold")
 

--- a/copernicus_marimo.py
+++ b/copernicus_marimo.py
@@ -320,17 +320,6 @@ def _(datetime, mo, timedelta):
         label="Crop to target area only (faster, less memory)",
     )
 
-    # Quality threshold slider — shared by S1 and S2
-    # Controls the minimum usable-pixel % to ACCEPT a tile
-    quality_threshold = mo.ui.slider(
-        start=50,
-        stop=100,
-        step=1,
-        value=90,
-        label="Quality threshold (% usable pixels to accept)",
-        show_value=True,
-    )
-
     # Search button triggers the search and download
     search_button = mo.ui.run_button(label="🔍 Search & Download")
 
@@ -342,7 +331,6 @@ def _(datetime, mo, timedelta):
         max_products,
         min_lat,
         min_lon,
-        quality_threshold,
         satellite_type,
         search_button,
         start_date,
@@ -359,7 +347,6 @@ def _(
     min_lat,
     min_lon,
     mo,
-    quality_threshold,
     satellite_type,
     search_button,
     start_date,
@@ -390,13 +377,6 @@ def _(
                 """
             ),
             crop_to_bbox,
-            mo.md(
-                """
-                **Quality Gate**: Minimum % of usable pixels to accept a tile.
-                Tiles below (threshold − 10%) are rejected; in between is marginal.
-                """
-            ),
-            quality_threshold,
             mo.callout(
                 mo.md(
                     """
@@ -727,7 +707,6 @@ def _(
     min_lat,
     min_lon,
     mo,
-    quality_threshold,
     satellite_type,
 ):
     """Create time slider and pre-process all images for fast rendering.
@@ -735,32 +714,43 @@ def _(
     This cell:
     1. Extracts dates from filenames and creates metadata
     2. Pre-processes ALL images into memory (cached)
-    3. Runs quality assessment (S1: invalid pixels / border noise, S2: cloud mask)
+    3. Runs quality assessment (S1: invalid pixels / border noise, S2: cloud/shadow)
     4. Creates slider widget for navigation
 
     Pre-processing happens once, making slider interactions instant.
-    The crop_to_bbox option controls whether to show full context or just target area.
 
-    For S1+S2 mode: Visualizes S2 images (optical), but both S1 and S2 are available for export.
+    For S1+S2 mode: Both S1 and S2 tiles are processed, quality-checked, and
+    shown in the viewer sorted by date. Each tile carries its own badge.
     """
     time_slider = None
     file_metadata = []
     cached_images = []
 
-    # Determine which files to visualize
-    _files_to_visualize = []
-    _viz_satellite_type = satellite_type.value
+    # Build a list of (file_path, sat_type) tuples to process
+    _work_items = []
 
     if satellite_type.value == "S1+S2":
-        # For S1+S2, visualize S2 images (more intuitive for users)
-        if isinstance(downloaded_files, dict) and "s2" in downloaded_files:
-            _files_to_visualize = downloaded_files["s2"]
-            _viz_satellite_type = "S2"
-    elif downloaded_files and not isinstance(downloaded_files, dict):
-        # Single satellite type (S1 or S2)
-        _files_to_visualize = downloaded_files
+        if isinstance(downloaded_files, dict):
+            for _f in downloaded_files.get("s2", []):
+                _work_items.append((_f, "S2"))
+            for _f in downloaded_files.get("s1", []):
+                _work_items.append((_f, "S1"))
+    elif (
+        satellite_type.value == "S2"
+        and downloaded_files
+        and not isinstance(downloaded_files, dict)
+    ):
+        for _f in downloaded_files:
+            _work_items.append((_f, "S2"))
+    elif (
+        satellite_type.value == "S1"
+        and downloaded_files
+        and not isinstance(downloaded_files, dict)
+    ):
+        for _f in downloaded_files:
+            _work_items.append((_f, "S1"))
 
-    if _files_to_visualize and len(_files_to_visualize) > 0:
+    if _work_items:
         # Show progress while pre-processing
         with mo.status.spinner(title="Pre-processing images for fast slider...") as _spinner:
             import re
@@ -770,11 +760,14 @@ def _(
             _use_bbox = crop_to_bbox.value  # User's choice
 
             # Import quality functions
-            from src.data.copernicus.quality import assess_s1_quality, quality_gate
+            from src.data.copernicus.quality import (
+                assess_s1_quality,
+                assess_s2_quality,
+            )
 
             # Extract dates and pre-process images
-            for _idx, _file_path in enumerate(_files_to_visualize):
-                _spinner.update(title=f"Processing image {_idx + 1}/{len(_files_to_visualize)}...")
+            for _idx, (_file_path, _sat) in enumerate(_work_items):
+                _spinner.update(title=f"Processing {_sat} image {_idx + 1}/{len(_work_items)}...")
 
                 _filename = _file_path.name
 
@@ -791,15 +784,13 @@ def _(
                 # Pre-process the image based on satellite type
                 _processed_data = None
                 try:
-                    if _viz_satellite_type == "S2":
-                        # Sentinel-2: Extract RGB composite
+                    if _sat == "S2":
                         from src.data.copernicus.image_processing import extract_rgb_composite
 
                         _processed_data = extract_rgb_composite(
                             _file_path, bbox=_bbox if _use_bbox else None
                         )
                     else:
-                        # Sentinel-1: Extract SAR data (VV polarization)
                         from src.data.copernicus.image_processing import extract_sar_composite
 
                         _processed_data = extract_sar_composite(
@@ -814,18 +805,14 @@ def _(
                     ):
                         # --- Quality assessment ---
                         _quality_report = None
-                        _quality_verdict = None
 
-                        if _viz_satellite_type == "S1":
-                            _spinner.update(
-                                title=f"Quality check {_idx + 1}/{len(_files_to_visualize)}..."
-                            )
+                        _spinner.update(
+                            title=f"Quality check {_sat} {_idx + 1}/{len(_work_items)}..."
+                        )
+                        if _sat == "S1":
                             _quality_report = assess_s1_quality(_file_path)
-                            if _quality_report is not None:
-                                _quality_verdict = quality_gate(
-                                    _quality_report["usable_pct"],
-                                    threshold=quality_threshold.value,
-                                )
+                        else:
+                            _quality_report = assess_s2_quality(_file_path)
 
                         # Store metadata and cached image data
                         file_metadata.append(
@@ -834,8 +821,8 @@ def _(
                                 "date": _date_obj,
                                 "date_str": _date_display,
                                 "filename": _filename,
+                                "sat_type": _sat,
                                 "quality_report": _quality_report,
-                                "quality_verdict": _quality_verdict,
                             }
                         )
                         cached_images.append(_processed_data)
@@ -894,8 +881,8 @@ def _(cached_images, mo, satellite_type):
             # S1: Show SAR recipes only
             _recipe_names = [r.name for rid, r in _recipes.items() if rid.startswith("sar_")]
         else:  # S1+S2
-            # S1+S2: Show optical recipes (visualizing S2)
-            _recipe_names = [r.name for rid, r in _recipes.items() if not rid.startswith("sar_")]
+            # S1+S2: Show all recipes (both optical and SAR tiles are in the viewer)
+            _recipe_names = [r.name for rid, r in _recipes.items()]
 
         if _recipe_names:
             band_recipe_selector = mo.ui.dropdown(
@@ -907,47 +894,120 @@ def _(cached_images, mo, satellite_type):
 
 
 @app.cell
-def _(band_recipe_selector, cached_images, file_metadata, mo, time_slider):
-    """Display time slider and adjustment sliders in a compact side-by-side layout."""
+def _(cached_images, file_metadata, mo):
+    """Create quality threshold sliders (separate cell so they don't reset on interaction)."""
+    s2_quality_threshold = None
+    s1_quality_threshold = None
+
+    if cached_images and len(cached_images) > 0:
+        # Check which satellite types are present
+        _has_s2 = any(m.get("sat_type") == "S2" for m in file_metadata)
+        _has_s1 = any(m.get("sat_type") == "S1" for m in file_metadata)
+
+        if _has_s2:
+            s2_quality_threshold = mo.ui.slider(
+                start=0,
+                stop=100,
+                step=5,
+                value=50,
+                label="S2 min usable % (cloud/shadow filter)",
+                show_value=True,
+            )
+        if _has_s1:
+            s1_quality_threshold = mo.ui.slider(
+                start=0,
+                stop=100,
+                step=5,
+                value=50,
+                label="S1 min usable % (invalid pixel filter)",
+                show_value=True,
+            )
+
+    return (s1_quality_threshold, s2_quality_threshold)
+
+
+@app.cell
+def _(
+    band_recipe_selector,
+    cached_images,
+    file_metadata,
+    mo,
+    s1_quality_threshold,
+    s2_quality_threshold,
+    time_slider,
+):
+    """Display time slider, quality filter, and adjustment sliders."""
     slider_display = None
     contrast_slider = None
     brightness_slider = None
     gamma_slider = None
+    filtered_indices = []
 
     if cached_images and len(cached_images) > 0:
-        # Create adjustment sliders (0-100 range, will be normalized in visualization)
+        # Compute filtered indices — each sat type uses its own threshold
+        _s2_thresh = s2_quality_threshold.value if s2_quality_threshold is not None else 0
+        _s1_thresh = s1_quality_threshold.value if s1_quality_threshold is not None else 0
+
+        for _i, _meta in enumerate(file_metadata):
+            _qr = _meta.get("quality_report")
+            if _qr is None:
+                filtered_indices.append(_i)
+                continue
+            _sat = _meta.get("sat_type", "S2")
+            _thresh = _s2_thresh if _sat == "S2" else _s1_thresh
+            if _qr["usable_pct"] >= _thresh:
+                filtered_indices.append(_i)
+
+        _total = len(file_metadata)
+        _kept = len(filtered_indices)
+        _removed = _total - _kept
+
+        # Create adjustment sliders
         contrast_slider = mo.ui.slider(
             start=0,
             stop=100,
             step=1,
-            value=50,  # 50 = 1.0x (no change)
+            value=50,
             label="Contrast",
             show_value=True,
         )
-
         brightness_slider = mo.ui.slider(
             start=0,
             stop=100,
             step=1,
-            value=50,  # 50 = 0.0 (no change)
+            value=50,
             label="Brightness",
             show_value=True,
         )
-
         gamma_slider = mo.ui.slider(
             start=0,
             stop=100,
             step=1,
-            value=50,  # 50 = 1.0 (no change)
+            value=50,
             label="Gamma",
             show_value=True,
         )
 
-        # Build the layout based on whether we have time slider
+        # Build the layout
         if time_slider is not None and len(file_metadata) > 1:
-            # Get current selection
             _current_idx = time_slider.value
             _current_meta = file_metadata[_current_idx]
+
+            # Quality filter summary
+            if _removed > 0:
+                _filter_summary = mo.md(
+                    f"**Showing {_kept} of {_total} images** ({_removed} filtered out)"
+                )
+            else:
+                _filter_summary = mo.md(f"**All {_total} images pass** quality filters")
+
+            # Build quality filter controls
+            _quality_controls = [mo.md("**Quality filter**")]
+            if s2_quality_threshold is not None:
+                _quality_controls.append(s2_quality_threshold)
+            if s1_quality_threshold is not None:
+                _quality_controls.append(s1_quality_threshold)
+            _quality_controls.append(_filter_summary)
 
             # Build adjustment controls
             _adjustment_controls = [
@@ -956,12 +1016,9 @@ def _(band_recipe_selector, cached_images, file_metadata, mo, time_slider):
                 brightness_slider,
                 gamma_slider,
             ]
-
-            # Add band recipe selector if available
             if band_recipe_selector is not None:
                 _adjustment_controls.insert(1, band_recipe_selector)
 
-            # Create two-column layout: time slider on left, adjustments on right
             slider_display = mo.vstack(
                 [
                     mo.md(
@@ -972,14 +1029,16 @@ def _(band_recipe_selector, cached_images, file_metadata, mo, time_slider):
                     ),
                     mo.hstack(
                         [
-                            # Left column: Time slider
+                            # Left column: Quality filters + time slider
                             mo.vstack(
-                                [
-                                    mo.md(f"**Navigate through {len(file_metadata)} images**"),
+                                _quality_controls
+                                + [
+                                    mo.md("---"),
+                                    mo.md(f"**Navigate through {_total} images**"),
                                     time_slider,
                                     mo.md(
                                         f"""
-                                        **Image {_current_idx + 1} of {len(file_metadata)}**
+                                        **Image {_current_idx + 1} of {_total}**
                                         Date: {_current_meta['date_str']}
                                         File: `{_current_meta['filename'][:40]}...`
                                         """
@@ -987,7 +1046,7 @@ def _(band_recipe_selector, cached_images, file_metadata, mo, time_slider):
                                 ],
                                 align="start",
                             ),
-                            # Right column: Adjustment sliders and band recipe
+                            # Right column: Adjustment sliders
                             mo.vstack(_adjustment_controls, align="start"),
                         ],
                         justify="start",
@@ -995,18 +1054,20 @@ def _(band_recipe_selector, cached_images, file_metadata, mo, time_slider):
                 ]
             )
         elif file_metadata and len(file_metadata) == 1:
-            # Build adjustment controls
             _adjustment_controls = [
                 contrast_slider,
                 brightness_slider,
                 gamma_slider,
             ]
-
-            # Add band recipe selector if available
             if band_recipe_selector is not None:
                 _adjustment_controls.insert(0, band_recipe_selector)
 
-            # Single image - just show adjustments compactly
+            _quality_widgets = []
+            if s2_quality_threshold is not None:
+                _quality_widgets.append(s2_quality_threshold)
+            if s1_quality_threshold is not None:
+                _quality_widgets.append(s1_quality_threshold)
+
             slider_display = mo.vstack(
                 [
                     mo.md(
@@ -1017,6 +1078,9 @@ def _(band_recipe_selector, cached_images, file_metadata, mo, time_slider):
                         **Date**: {file_metadata[0]['date_str']} | **File**: `{file_metadata[0]['filename'][:50]}...`
                         """
                     ),
+                ]
+                + _quality_widgets
+                + [
                     mo.hstack(_adjustment_controls, justify="start"),
                 ]
             )
@@ -1025,6 +1089,7 @@ def _(band_recipe_selector, cached_images, file_metadata, mo, time_slider):
     return (
         brightness_slider,
         contrast_slider,
+        filtered_indices,
         gamma_slider,
     )
 
@@ -1095,13 +1160,15 @@ def _(
     contrast_slider,
     crop_to_bbox,
     file_metadata,
+    filtered_indices,
     gamma_slider,
     max_lat,
     max_lon,
     min_lat,
     min_lon,
     mo,
-    quality_threshold,
+    s1_quality_threshold,
+    s2_quality_threshold,
     satellite_type,
     time_slider,
     traceback,
@@ -1111,11 +1178,8 @@ def _(
     This cell displays pre-processed images from cache, making slider
     interactions nearly instant (no disk I/O or processing needed).
 
-    Visualization details:
-    - S2: Supports multiple band recipes (True Color, False Color, Agriculture, NDVI, NDWI)
-    - S1: VV polarization (grayscale) with adaptive contrast
-    - Both: Already cropped to target bbox during pre-processing
-    - Image adjustments applied in real-time based on slider values
+    Images that fall below the quality threshold show a semi-transparent
+    "FILTERED OUT" overlay so the user can still inspect them.
     """
     viz_result = None
 
@@ -1156,11 +1220,12 @@ def _(
             _needs_recipe_processing = False
 
             # Determine if we need to reprocess with recipe
+            _current_sat = _metadata.get("sat_type", satellite_type.value)
             if _selected_recipe is not None:
-                if satellite_type.value in ["S2", "S1+S2"]:
+                if _current_sat in ("S2",):
                     # S2: Reprocess if not True Color
                     _needs_recipe_processing = _selected_recipe != "True Color (RGB)"
-                elif satellite_type.value == "S1":
+                elif _current_sat in ("S1",):
                     # S1: Reprocess if not default SAR VV
                     _needs_recipe_processing = _selected_recipe != "SAR VV (Surface)"
 
@@ -1396,25 +1461,76 @@ def _(
                 ax.set_ylabel("Latitude (°N)", fontsize=12)
 
                 # Update title to show recipe name and quality badge
-                _recipe_name = _selected_recipe if _selected_recipe else satellite_type.value
+                _recipe_name = (
+                    _selected_recipe
+                    if _selected_recipe
+                    else _metadata.get("sat_type", satellite_type.value)
+                )
 
-                # Build quality badge string for S1 tiles
+                # Build quality badge string for S1 and S2 tiles
                 _quality_badge = ""
+                _is_filtered_out = False
                 _qr = _metadata.get("quality_report")
+                _current_sat = _metadata.get("sat_type", "S2")
                 if _qr is not None:
+                    # Pick the right threshold for this satellite type
+                    if _current_sat == "S2":
+                        _threshold_val = (
+                            s2_quality_threshold.value if s2_quality_threshold is not None else 50
+                        )
+                    else:
+                        _threshold_val = (
+                            s1_quality_threshold.value if s1_quality_threshold is not None else 50
+                        )
+
                     from src.data.copernicus.quality import quality_gate as _qg
 
-                    _verdict = _qg(_qr["usable_pct"], threshold=quality_threshold.value)
+                    _verdict = _qg(_qr["usable_pct"], threshold=_threshold_val)
+                    _is_filtered_out = _selected_idx not in filtered_indices
                     if _verdict == "ACCEPT":
-                        _quality_badge = f"  🟢 ACCEPT — {_qr['usable_pct']:.1f}% valid"
+                        _quality_badge = f"  🟢 ACCEPT — {_qr['usable_pct']:.1f}% usable"
                     elif _verdict == "MARGINAL":
-                        _quality_badge = f"  🟡 MARGINAL — {_qr['usable_pct']:.1f}% valid"
+                        _quality_badge = f"  🟡 MARGINAL — {_qr['usable_pct']:.1f}% usable"
                     else:
-                        _quality_badge = f"  🔴 REJECT — {_qr['usable_pct']:.1f}% valid"
+                        _quality_badge = f"  🔴 REJECT — {_qr['usable_pct']:.1f}% usable"
+
+                    # S2-specific details
+                    if "cloud_pct" in _qr:
+                        _quality_badge += (
+                            f"  | ☁️ {_qr['cloud_pct']:.1f}%" f"  🌑 {_qr['shadow_pct']:.1f}%"
+                        )
+                    # S1-specific details
                     if _qr.get("border_noise_detected"):
                         _quality_badge += "  ⚠️ border noise"
                     if _qr.get("orbit_type"):
                         _quality_badge += f"  | orbit: {_qr['orbit_type']}"
+
+                # Add "FILTERED OUT" overlay for rejected images
+                if _is_filtered_out:
+                    ax.add_patch(
+                        plt.Rectangle(
+                            (0, 0),
+                            1,
+                            1,
+                            transform=ax.transAxes,
+                            facecolor="red",
+                            alpha=0.25,
+                            zorder=10,
+                        )
+                    )
+                    ax.text(
+                        0.5,
+                        0.5,
+                        "⛔ FILTERED OUT",
+                        transform=ax.transAxes,
+                        ha="center",
+                        va="center",
+                        fontsize=28,
+                        fontweight="bold",
+                        color="red",
+                        alpha=0.7,
+                        zorder=11,
+                    )
 
                 _title = (
                     f"{_recipe_name} - {_metadata['date_str']}\n"

--- a/copernicus_marimo.py
+++ b/copernicus_marimo.py
@@ -898,6 +898,7 @@ def _(cached_images, file_metadata, mo):
     """Create quality threshold sliders (separate cell so they don't reset on interaction)."""
     s2_quality_threshold = None
     s1_quality_threshold = None
+    s2_nodata_threshold = None
 
     if cached_images and len(cached_images) > 0:
         # Check which satellite types are present
@@ -913,6 +914,14 @@ def _(cached_images, file_metadata, mo):
                 label="S2 min usable % (cloud/shadow filter)",
                 show_value=True,
             )
+            s2_nodata_threshold = mo.ui.slider(
+                start=0,
+                stop=100,
+                step=5,
+                value=20,
+                label="S2 max nodata % (data gap filter)",
+                show_value=True,
+            )
         if _has_s1:
             s1_quality_threshold = mo.ui.slider(
                 start=0,
@@ -923,7 +932,7 @@ def _(cached_images, file_metadata, mo):
                 show_value=True,
             )
 
-    return (s1_quality_threshold, s2_quality_threshold)
+    return (s1_quality_threshold, s2_nodata_threshold, s2_quality_threshold)
 
 
 @app.cell
@@ -933,6 +942,7 @@ def _(
     file_metadata,
     mo,
     s1_quality_threshold,
+    s2_nodata_threshold,
     s2_quality_threshold,
     time_slider,
 ):
@@ -944,9 +954,10 @@ def _(
     filtered_indices = []
 
     if cached_images and len(cached_images) > 0:
-        # Compute filtered indices — each sat type uses its own threshold
+        # Compute filtered indices — each sat type uses its own thresholds
         _s2_thresh = s2_quality_threshold.value if s2_quality_threshold is not None else 0
         _s1_thresh = s1_quality_threshold.value if s1_quality_threshold is not None else 0
+        _s2_nodata_max = s2_nodata_threshold.value if s2_nodata_threshold is not None else 100
 
         for _i, _meta in enumerate(file_metadata):
             _qr = _meta.get("quality_report")
@@ -954,9 +965,15 @@ def _(
                 filtered_indices.append(_i)
                 continue
             _sat = _meta.get("sat_type", "S2")
-            _thresh = _s2_thresh if _sat == "S2" else _s1_thresh
-            if _qr["usable_pct"] >= _thresh:
-                filtered_indices.append(_i)
+            if _sat == "S2":
+                # S2: check usable % AND nodata %
+                _nodata_total = _qr.get("nodata_pct", 0) + _qr.get("defective_pct", 0)
+                if _qr["usable_pct"] >= _s2_thresh and _nodata_total <= _s2_nodata_max:
+                    filtered_indices.append(_i)
+            else:
+                # S1: check usable % only
+                if _qr["usable_pct"] >= _s1_thresh:
+                    filtered_indices.append(_i)
 
         _total = len(file_metadata)
         _kept = len(filtered_indices)
@@ -1005,6 +1022,8 @@ def _(
             _quality_controls = [mo.md("**Quality filter**")]
             if s2_quality_threshold is not None:
                 _quality_controls.append(s2_quality_threshold)
+            if s2_nodata_threshold is not None:
+                _quality_controls.append(s2_nodata_threshold)
             if s1_quality_threshold is not None:
                 _quality_controls.append(s1_quality_threshold)
             _quality_controls.append(_filter_summary)
@@ -1065,6 +1084,8 @@ def _(
             _quality_widgets = []
             if s2_quality_threshold is not None:
                 _quality_widgets.append(s2_quality_threshold)
+            if s2_nodata_threshold is not None:
+                _quality_widgets.append(s2_nodata_threshold)
             if s1_quality_threshold is not None:
                 _quality_widgets.append(s1_quality_threshold)
 
@@ -1168,6 +1189,7 @@ def _(
     min_lon,
     mo,
     s1_quality_threshold,
+    s2_nodata_threshold,
     s2_quality_threshold,
     satellite_type,
     time_slider,
@@ -1486,6 +1508,16 @@ def _(
                     from src.data.copernicus.quality import quality_gate as _qg
 
                     _verdict = _qg(_qr["usable_pct"], threshold=_threshold_val)
+
+                    # S2: also reject if nodata exceeds threshold
+                    if _current_sat == "S2":
+                        _nodata_max = (
+                            s2_nodata_threshold.value if s2_nodata_threshold is not None else 100
+                        )
+                        _nodata_total = _qr.get("nodata_pct", 0) + _qr.get("defective_pct", 0)
+                        if _nodata_total > _nodata_max and _verdict != "REJECT":
+                            _verdict = "REJECT"
+
                     _is_filtered_out = _selected_idx not in filtered_indices
                     if _verdict == "ACCEPT":
                         _quality_badge = f"  🟢 ACCEPT — {_qr['usable_pct']:.1f}% usable"
@@ -1499,6 +1531,13 @@ def _(
                         _quality_badge += (
                             f"  | ☁️ {_qr['cloud_pct']:.1f}%" f"  🌑 {_qr['shadow_pct']:.1f}%"
                         )
+                        _nodata_val = _qr.get("nodata_pct", 0)
+                        _defective_val = _qr.get("defective_pct", 0)
+                        if _nodata_val > 0 or _defective_val > 0:
+                            _quality_badge += (
+                                f"  ⬛ {_nodata_val:.1f}% nodata"
+                                f"  🔧 {_defective_val:.1f}% defective"
+                            )
                     # S1-specific details
                     if _qr.get("border_noise_detected"):
                         _quality_badge += "  ⚠️ border noise"

--- a/src/data/copernicus/__init__.py
+++ b/src/data/copernicus/__init__.py
@@ -34,6 +34,7 @@ from .indices import (
 from .quality import (
     apply_cloud_mask_to_image,
     assess_s1_quality,
+    assess_s2_quality,
     extract_cloud_mask,
     quality_gate,
 )
@@ -78,6 +79,7 @@ __all__ = [
     "extract_cloud_mask",
     "apply_cloud_mask_to_image",
     "assess_s1_quality",
+    "assess_s2_quality",
     "quality_gate",
     # Spectral indices
     "calculate_ndvi",

--- a/src/data/copernicus/__init__.py
+++ b/src/data/copernicus/__init__.py
@@ -31,7 +31,12 @@ from .indices import (
     calculate_ndwi,
     calculate_savi,
 )
-from .quality import apply_cloud_mask_to_image, extract_cloud_mask
+from .quality import (
+    apply_cloud_mask_to_image,
+    assess_s1_quality,
+    extract_cloud_mask,
+    quality_gate,
+)
 from .utils import create_validated_bbox, find_granule_directory
 from .visualization import (
     create_band_analysis_plot,
@@ -72,6 +77,8 @@ __all__ = [
     # Quality control
     "extract_cloud_mask",
     "apply_cloud_mask_to_image",
+    "assess_s1_quality",
+    "quality_gate",
     # Spectral indices
     "calculate_ndvi",
     "calculate_ndwi",

--- a/src/data/copernicus/quality.py
+++ b/src/data/copernicus/quality.py
@@ -201,6 +201,7 @@ def assess_s2_quality(zip_file_path: Path) -> Optional[Dict[str, Any]]:
                 "cloud_pct": 42.3,
                 "shadow_pct": 5.1,
                 "nodata_pct": 0.0,
+                "defective_pct": 0.0,
                 "snow_pct": 0.0,
                 "usable_pct": 52.6,
             }
@@ -240,7 +241,8 @@ def assess_s2_quality(zip_file_path: Path) -> Optional[Dict[str, Any]]:
             def _pct(mask: np.ndarray) -> float:
                 return float(np.sum(mask) / total * 100.0)
 
-            nodata_pct = _pct(np.isin(scl, [0, 1]))  # No data + saturated
+            nodata_pct = _pct(scl == 0)  # No data (edge of orbit, missing strips)
+            defective_pct = _pct(scl == 1)  # Saturated / defective (sensor artifacts)
             shadow_pct = _pct(np.isin(scl, [2, 3]))  # Dark area + cloud shadow
             cloud_pct = _pct(np.isin(scl, [8, 9, 10]))  # Cloud med/high + cirrus
             snow_pct = _pct(scl == 11)  # Snow / ice
@@ -250,6 +252,7 @@ def assess_s2_quality(zip_file_path: Path) -> Optional[Dict[str, Any]]:
                 "cloud_pct": round(cloud_pct, 2),
                 "shadow_pct": round(shadow_pct, 2),
                 "nodata_pct": round(nodata_pct, 2),
+                "defective_pct": round(defective_pct, 2),
                 "snow_pct": round(snow_pct, 2),
                 "usable_pct": round(usable_pct, 2),
             }

--- a/src/data/copernicus/quality.py
+++ b/src/data/copernicus/quality.py
@@ -167,6 +167,102 @@ def apply_cloud_mask_to_image(
 
 
 # ---------------------------------------------------------------------------
+# Sentinel-2 quality assessment (SCL-based)
+# ---------------------------------------------------------------------------
+
+
+def assess_s2_quality(zip_file_path: Path) -> Optional[Dict[str, Any]]:
+    """Assess quality of a Sentinel-2 L2A product using the SCL band.
+
+    Reads the Scene Classification Layer and counts pixels per category to
+    produce a detailed quality report.
+
+    SCL classes:
+        0  = No Data
+        1  = Saturated / defective
+        2  = Dark area (topographic shadow)
+        3  = Cloud shadow
+        4  = Vegetation  (USABLE)
+        5  = Bare soil   (USABLE)
+        6  = Water       (USABLE)
+        7  = Unclassified
+        8  = Cloud medium probability
+        9  = Cloud high probability
+        10 = Thin cirrus
+        11 = Snow / ice
+
+    Args:
+        zip_file_path: Path to a Sentinel-2 Level-2A ZIP file.
+
+    Returns:
+        Quality report dict, or None on failure::
+
+            {
+                "cloud_pct": 42.3,
+                "shadow_pct": 5.1,
+                "nodata_pct": 0.0,
+                "snow_pct": 0.0,
+                "usable_pct": 52.6,
+            }
+    """
+    try:
+        with extract_s2_safe_structure(zip_file_path) as (safe_dir, granule_dir):
+            if "MSIL1C" in safe_dir.name:
+                print(
+                    f"Warning: {zip_file_path.name} is Level-1C (no SCL band). "
+                    "Quality assessment requires Level-2A products."
+                )
+                return None
+
+            # Locate SCL band (same logic as extract_cloud_mask)
+            img_dir_20m = granule_dir / "IMG_DATA" / "R20m"
+            if not img_dir_20m.exists():
+                img_dir_20m = granule_dir / "IMG_DATA"
+
+            scl_file = None
+            for pattern in ("*_SCL_20m.jp2", "*_SCL.jp2", "*SCL*.jp2"):
+                matches = list(img_dir_20m.glob(pattern))
+                if matches:
+                    scl_file = matches[0]
+                    break
+
+            if scl_file is None:
+                print(f"SCL band not found in {zip_file_path.name}")
+                return None
+
+            with rasterio.open(scl_file) as src:
+                scl = src.read(1)
+
+            total = scl.size
+            if total == 0:
+                return None
+
+            def _pct(mask: np.ndarray) -> float:
+                return float(np.sum(mask) / total * 100.0)
+
+            nodata_pct = _pct(np.isin(scl, [0, 1]))  # No data + saturated
+            shadow_pct = _pct(np.isin(scl, [2, 3]))  # Dark area + cloud shadow
+            cloud_pct = _pct(np.isin(scl, [8, 9, 10]))  # Cloud med/high + cirrus
+            snow_pct = _pct(scl == 11)  # Snow / ice
+            usable_pct = _pct(np.isin(scl, [4, 5, 6]))  # Vegetation + bare + water
+
+            return {
+                "cloud_pct": round(cloud_pct, 2),
+                "shadow_pct": round(shadow_pct, 2),
+                "nodata_pct": round(nodata_pct, 2),
+                "snow_pct": round(snow_pct, 2),
+                "usable_pct": round(usable_pct, 2),
+            }
+
+    except Exception as e:
+        print(f"Error assessing S2 quality for {zip_file_path.name}: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return None
+
+
+# ---------------------------------------------------------------------------
 # Sentinel-1 SAR quality assessment
 # ---------------------------------------------------------------------------
 

--- a/src/data/copernicus/quality.py
+++ b/src/data/copernicus/quality.py
@@ -1,11 +1,16 @@
-"""Quality control utilities for Copernicus Sentinel-2 satellite data.
+"""Quality control utilities for Copernicus Sentinel-1 and Sentinel-2 satellite data.
 
-This module provides functions for quality assessment and masking of Sentinel-2
-optical imagery, particularly cloud masking using the Scene Classification Layer (SCL).
+This module provides functions for quality assessment and masking of satellite imagery:
+- Sentinel-2: Cloud masking using the Scene Classification Layer (SCL)
+- Sentinel-1: Invalid pixel detection, border noise detection, orbit type extraction
+- Shared quality_gate() verdict function for both S1 and S2 reports
 """
 
+import tempfile
+import xml.etree.ElementTree as ET
+import zipfile
 from pathlib import Path
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import numpy as np
 import rasterio
@@ -159,3 +164,246 @@ def apply_cloud_mask_to_image(
         raise ValueError(f"Unsupported image dimensions: {image_array.ndim}")
 
     return masked_image
+
+
+# ---------------------------------------------------------------------------
+# Sentinel-1 SAR quality assessment
+# ---------------------------------------------------------------------------
+
+
+def _count_invalid_pixels(band_data: np.ndarray) -> float:
+    """Count the percentage of invalid pixels in a SAR band.
+
+    Invalid pixels are: zero (no data received), NaN, or extreme outliers
+    (values beyond ±5 standard deviations from the mean of valid pixels).
+
+    Args:
+        band_data: 2-D array of SAR backscatter values (linear scale).
+
+    Returns:
+        Percentage of invalid pixels (0.0–100.0).
+    """
+    total = band_data.size
+    if total == 0:
+        return 100.0
+
+    # Zeros and NaNs
+    invalid_mask = np.isnan(band_data) | np.isinf(band_data) | (band_data == 0)
+
+    # Outlier detection on the valid subset
+    valid = band_data[~invalid_mask]
+    if valid.size > 0:
+        mean = valid.mean()
+        std = valid.std()
+        if std > 0:
+            outlier_mask = np.abs(band_data - mean) > 5 * std
+            invalid_mask = invalid_mask | outlier_mask
+
+    return float(np.sum(invalid_mask) / total * 100.0)
+
+
+def _detect_border_noise(
+    band_data: np.ndarray,
+    edge_pixels: int = 50,
+    zero_threshold: float = 0.9,
+) -> bool:
+    """Detect border noise in a SAR image.
+
+    S1 GRD products (especially pre-March 2018) have strips of noisy/zero
+    pixels along the swath edges.  We scan the first and last N columns/rows
+    and flag the tile if any edge is predominantly zero.
+
+    Args:
+        band_data: 2-D array of SAR backscatter values.
+        edge_pixels: Number of rows/columns to inspect at each edge.
+        zero_threshold: Fraction of near-zero pixels that triggers the flag.
+
+    Returns:
+        True if border noise is detected on any edge.
+    """
+    h, w = band_data.shape
+    edge_pixels = min(edge_pixels, h // 4, w // 4)  # Don't exceed quarter of image
+    if edge_pixels < 1:
+        return False
+
+    near_zero = 1e-10  # Threshold for "near-zero" in linear scale
+
+    edges = [
+        band_data[:edge_pixels, :],  # top rows
+        band_data[-edge_pixels:, :],  # bottom rows
+        band_data[:, :edge_pixels],  # left columns
+        band_data[:, -edge_pixels:],  # right columns
+    ]
+
+    for edge in edges:
+        zero_frac = np.sum(np.abs(edge) < near_zero) / edge.size
+        if zero_frac >= zero_threshold:
+            return True
+
+    return False
+
+
+def _extract_orbit_type(safe_dir: Path) -> Optional[str]:
+    """Extract orbit type (precise / restituted) from manifest.safe.
+
+    The manifest.safe XML inside the .SAFE directory contains a
+    ``<s1sarl1:orbitReference>`` element whose child
+    ``<safe:extension><s1sarl1:orbitProperties><s1sarl1:pass>`` or
+    ``<safe:orbitNumber>`` attributes indicate the orbit file used.
+    The key field is ``<s1sarl1:extension><s1sarl1:orbitProperties>``
+    with ``type`` attribute, but the most reliable indicator is the
+    ``metadataObject`` with ID ``measurementOrbitReference`` whose
+    ``xmlData`` contains the orbit file name.  Orbit file names
+    starting with ``AUX_POEORB`` = precise, ``AUX_RESORB`` = restituted.
+
+    Falls back to searching for the raw strings in the XML text.
+
+    Args:
+        safe_dir: Path to the extracted .SAFE directory.
+
+    Returns:
+        ``"precise"``, ``"restituted"``, or ``None`` if undetermined.
+    """
+    manifest = safe_dir / "manifest.safe"
+    if not manifest.exists():
+        return None
+
+    try:
+        content = manifest.read_text(errors="replace")
+
+        # Fast string search — orbit file references are embedded in the XML
+        if "AUX_POEORB" in content:
+            return "precise"
+        if "AUX_RESORB" in content:
+            return "restituted"
+
+        # Fallback: try XML parsing for less common layouts
+        tree = ET.parse(manifest)
+        root = tree.getroot()
+        xml_str = ET.tostring(root, encoding="unicode")
+        if "AUX_POEORB" in xml_str:
+            return "precise"
+        if "AUX_RESORB" in xml_str:
+            return "restituted"
+
+    except Exception as e:
+        print(f"Warning: could not parse orbit type from manifest.safe: {e}")
+
+    return None
+
+
+def assess_s1_quality(
+    zip_file_path: Path,
+    edge_pixels: int = 50,
+) -> Optional[Dict[str, Any]]:
+    """Assess quality of a Sentinel-1 GRD product.
+
+    Opens the ZIP, reads VV/VH TIFF bands, and computes:
+    - invalid_pixel_pct: percentage of zero / NaN / outlier pixels
+    - border_noise_detected: boolean flag for swath-edge noise
+    - orbit_type: "precise" or "restituted" (from manifest.safe)
+    - usable_pct: 100 - invalid_pixel_pct
+
+    Args:
+        zip_file_path: Path to a Sentinel-1 ZIP file (GRD product).
+        edge_pixels: Number of edge rows/cols to scan for border noise.
+
+    Returns:
+        Quality report dict, or None on failure::
+
+            {
+                "invalid_pixel_pct": 3.2,
+                "border_noise_detected": True,
+                "orbit_type": "precise",
+                "usable_pct": 96.8,
+            }
+    """
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+
+            with zipfile.ZipFile(zip_file_path, "r") as zf:
+                zf.extractall(tmp_path)
+
+            safe_dirs = list(tmp_path.glob("*.SAFE"))
+            if not safe_dirs:
+                print(f"No .SAFE directory in {zip_file_path.name}")
+                return None
+            safe_dir = safe_dirs[0]
+
+            # --- Read polarization TIFFs ---
+            measurement_dir = safe_dir / "measurement"
+            if not measurement_dir.exists():
+                print(f"No measurement/ directory in {zip_file_path.name}")
+                return None
+
+            tiff_files = list(measurement_dir.glob("*.tiff"))
+            if not tiff_files:
+                print(f"No TIFF files in {zip_file_path.name}")
+                return None
+
+            # Aggregate invalid-pixel stats across all polarisation bands
+            all_invalid_pcts: list[float] = []
+            border_noise = False
+
+            for tiff in tiff_files:
+                with rasterio.open(tiff) as src:
+                    data = src.read(1).astype(np.float32)
+
+                all_invalid_pcts.append(_count_invalid_pixels(data))
+
+                if not border_noise:
+                    border_noise = _detect_border_noise(data, edge_pixels=edge_pixels)
+
+            invalid_pct = float(np.mean(all_invalid_pcts)) if all_invalid_pcts else 100.0
+
+            # --- Orbit type ---
+            orbit_type = _extract_orbit_type(safe_dir)
+
+            return {
+                "invalid_pixel_pct": round(invalid_pct, 2),
+                "border_noise_detected": border_noise,
+                "orbit_type": orbit_type,
+                "usable_pct": round(100.0 - invalid_pct, 2),
+            }
+
+    except Exception as e:
+        print(f"Error assessing S1 quality for {zip_file_path.name}: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Shared quality gate (works for both S1 and S2 reports)
+# ---------------------------------------------------------------------------
+
+
+def quality_gate(
+    usable_pct: float,
+    threshold: float = 90.0,
+    marginal_offset: float = 10.0,
+) -> str:
+    """Return a quality verdict based on usable pixel percentage.
+
+    The same function is used for both S2 (cloud-free %) and S1 (valid pixel %).
+
+    Verdicts:
+    - ``"ACCEPT"``   — usable_pct >= threshold
+    - ``"MARGINAL"`` — usable_pct >= threshold - marginal_offset
+    - ``"REJECT"``   — usable_pct < threshold - marginal_offset
+
+    Args:
+        usable_pct: Percentage of usable pixels (0–100).
+        threshold: Minimum usable % to fully accept (default 90).
+        marginal_offset: Width of the marginal band below threshold (default 10).
+
+    Returns:
+        One of ``"ACCEPT"``, ``"MARGINAL"``, ``"REJECT"``.
+    """
+    if usable_pct >= threshold:
+        return "ACCEPT"
+    if usable_pct >= threshold - marginal_offset:
+        return "MARGINAL"
+    return "REJECT"


### PR DESCRIPTION
## Summary

Adds three interactive quality filters to the Copernicus pipeline so users can discard or flag corrupted/unusable satellite tiles before downstream processing.

### Filter 1 — S1 SAR Quality Gate (#1058)
- `assess_s1_quality()` checks S1 GRD products for invalid pixels (zero/NaN/outliers), border noise (swath-edge artifacts), and orbit type (precise vs restituted)
- Returns `{ invalid_pixel_pct, border_noise_detected, orbit_type, usable_pct }`
- Interactive slider: **S1 min usable %**

### Filter 2 — S2 Cloud/Shadow Quality Gate (#1057)
- `assess_s2_quality()` reads the SCL band and counts cloud, shadow, nodata, defective, and snow pixels
- Returns `{ cloud_pct, shadow_pct, nodata_pct, defective_pct, snow_pct, usable_pct }`
- Interactive slider: **S2 min usable %**

### Filter 3 — S2 Nodata & Defective Pixel Filter (#1059)
- Splits the old lumped `nodata_pct` (SCL classes 0+1) into separate `nodata_pct` (class 0) and `defective_pct` (class 1)
- Interactive slider: **S2 max nodata %** — rejects tiles with excessive data gaps even if cloud-free

### Shared infrastructure
- `quality_gate(usable_pct, threshold)` — shared verdict function returning ACCEPT / MARGINAL / REJECT
- All filters run automatically after download during pre-processing
- Quality badges on each image: 🟢 ACCEPT / 🟡 MARGINAL / 🔴 REJECT with detailed breakdown
- Filtered-out images show a red overlay in the viewer
- S1+S2 mode processes and quality-checks both satellite types

### Files changed
- `src/data/copernicus/quality.py` — `assess_s1_quality()`, `assess_s2_quality()`, `quality_gate()`, and helpers
- `src/data/copernicus/__init__.py` — updated exports
- `copernicus_marimo.py` — three filter sliders, quality badges, filtered-out overlay

All 23 existing tests pass.